### PR TITLE
NEW require member password change on next login admin option

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -1,0 +1,6 @@
+---
+Name: securityextensionsextensions
+---
+SilverStripe\Security\Member:
+  extensions:
+    securityMemberExtension: SilverStripe\SecurityExtensions\Extension\MemberExtension

--- a/client/dist/styles/bundle.css
+++ b/client/dist/styles/bundle.css
@@ -1,0 +1,1 @@
+.form-group--no-divider{margin-bottom:0;padding-bottom:0}.form-group--no-divider:after{display:none}

--- a/client/src/bundles/bundle.scss
+++ b/client/src/bundles/bundle.scss
@@ -1,0 +1,1 @@
+@import '../styles/cms-overrides';

--- a/client/src/styles/cms-overrides.scss
+++ b/client/src/styles/cms-overrides.scss
@@ -1,0 +1,12 @@
+/**
+ * Not actually an override, this adds a new style that allows form holders with the class applied to remove the
+ * divider below them in order to 'pseudo-group' elements together.
+ */
+.form-group--no-divider {
+  margin-bottom: 0;
+  padding-bottom: 0;
+
+  &::after {
+    display: none;
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "autoload": {
         "psr-4": {
             "SilverStripe\\SecurityExtensions\\": "src/",
-            "SilverStripe\\SecurityExtensions\\Tests\\": "tests/"
+            "SilverStripe\\SecurityExtensions\\Tests\\": "tests/php/"
         }
     },
     "extra": {

--- a/src/Extension/MemberExtension.php
+++ b/src/Extension/MemberExtension.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace SilverStripe\SecurityExtensions\Extension;
+
+use SilverStripe\Forms\CheckboxField;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\ORM\DataExtension;
+use SilverStripe\ORM\FieldType\DBDatetime;
+use SilverStripe\Security\Member;
+use SilverStripe\Security\Security;
+
+/**
+ * Extend Member to add relationship to registered methods and track some specific preferences
+ *
+ * @property Member|MemberExtension owner
+ */
+class MemberExtension extends DataExtension
+{
+    public function updateCMSFields(FieldList $fields)
+    {
+        $currentUser = Security::getCurrentUser();
+
+        // We can allow an admin to require a user to change their password however. But:
+        // - Don't show a read only field if the user cannot edit this record
+        // - Don't show if a user views their own profile (just let them reset their own password)
+        if ($currentUser && ($currentUser->ID !== $this->owner->ID) && $this->owner->canEdit()) {
+            $requireNewPassword = CheckboxField::create(
+                'RequirePasswordChangeOnNextLogin',
+                _t(__CLASS__ . 'RequirePasswordChangeOnNextLogin', 'Require password change on next login')
+            );
+            $fields->insertAfter('Password', $requireNewPassword);
+
+            $fields->dataFieldByName('Password')->addExtraClass('form-group--no-divider');
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Set password expiry to now to enforce a change of password next log in
+     *
+     * @param int|null $dataValue boolean representation checked/not checked {@see CheckboxField::dataValue}
+     * @return Member
+     */
+    public function saveRequirePasswordChangeOnNextLogin($dataValue)
+    {
+        if ($dataValue && $this->owner->canEdit()) {
+            // An expired password automatically requires a password change on logging in
+            $this->owner->PasswordExpiry = DBDatetime::now()->Rfc2822();
+        }
+        return $this->owner;
+    }
+}

--- a/tests/php/Extension/MemberExtensionTest.php
+++ b/tests/php/Extension/MemberExtensionTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace SilverStripe\SecuityExtensions\Tests\Extension;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Form;
+use SilverStripe\SecurityExtensions\Extension\MemberExtension;
+use SilverStripe\ORM\FieldType\DBDateTime;
+use SilverStripe\Security\Member;
+
+class MemberExtensionTest extends SapphireTest
+{
+    protected static $fixture_file = 'MemberExtensionTest.yml';
+
+    protected static $required_extensions = [
+        Member::class => [MemberExtension::class]
+    ];
+
+    public function testAdminCanRequirePasswordChangeOnNextLogIn()
+    {
+        /** @var Member&MemberExtension $targetMember */
+        $targetMember = $this->objFromFixture(Member::class, 'someone');
+        $this->logInWithPermission('ADMIN');
+        $field = $targetMember->getCMSFields()->dataFieldByName('RequirePasswordChangeOnNextLogin');
+        $this->assertNotNull($field);
+    }
+
+    public function testUserCannotRequireTheirOwnPasswordChangeOnNextLogIn()
+    {
+        /** @var Member&MemberExtension $targetMember */
+        $targetMember = $this->objFromFixture(Member::class, 'someone');
+        $this->logInAs($targetMember);
+        $field = $targetMember->getCMSFields()->dataFieldByName('RequirePasswordChangeOnNextLogin');
+        $this->assertNull($field);
+    }
+
+    public function testUserCannotRequireOthersToPasswordChangeOnNextLogIn()
+    {
+        /** @var Member&MemberExtension $targetMember */
+        $targetMember = $this->objFromFixture(Member::class, 'anyone');
+        $this->logInAs('someone');
+        $field = $targetMember->getCMSFields()->dataFieldByName('RequirePasswordChangeOnNextLogin');
+        $this->assertNull($field);
+    }
+
+    public function testCheckingRequirePasswordChangeOnNextLoginWillSetPasswordExpiryToNow()
+    {
+        $mockDate = '2019-03-02 00:00:00';
+        DBDateTime::set_mock_now($mockDate);
+
+        /** @var Member&MemberExtension $targetMember */
+        $targetMember = $this->objFromFixture(Member::class, 'someone');
+
+        $this->assertNull($targetMember->PasswordExpiry);
+
+        $this->logInWithPermission('ADMIN');
+        $fields = $targetMember->getCMSFields();
+        $form = new Form(null, 'SomeForm', $fields, new FieldList());
+        $field = $fields->dataFieldByName('RequirePasswordChangeOnNextLogin');
+        $field->setValue(1);
+        $form->saveInto($targetMember);
+
+        $this->assertEquals($mockDate, $targetMember->PasswordExpiry);
+    }
+}

--- a/tests/php/Extension/MemberExtensionTest.yml
+++ b/tests/php/Extension/MemberExtensionTest.yml
@@ -1,0 +1,7 @@
+SilverStripe\Security\Member:
+  someone:
+    FirstName: 'Someone'
+    Email: 'someone@example.com'
+  anyone:
+    FirstName: 'Anyone'
+    Email: 'anyone@example.com'


### PR DESCRIPTION
Add an option to the member adminstration form to require that user to change their password the next time they log in.
This is handled via existing functionality within the SilverStripe core by setting the password expirty date to 'now'.

In this manner an admin can set up a user and not know their password in the case that the user doesn't reset it, by simply forcing the reset.

Resolves https://github.com/silverstripe/silverstripe-mfa/issues/37