### PR TITLE
FIX underpriviliged users still need sudomode access

### DIFF
--- a/src/Control/SudoModeController.php
+++ b/src/Control/SudoModeController.php
@@ -42,6 +42,13 @@ class SudoModeController extends LeftAndMain
      */
     private $sudoModeService;
 
+    /**
+     * Explicitly disable required permissions for sudo mode checks
+     *
+     * @var boolean
+     */
+    private static $required_permission_codes = false;
+
     public function getClientConfig()
     {
         return [


### PR DESCRIPTION
Users with access to the CMS are not always explicitly given the permission code that was required to access generic LeftAndMain controllers. This would result in a 302 found and a redirect to e.g. admin/pages for a ContentEditor (one of the default roles in SilverStripe, and the group desigination assigned to the test user for this issue resolution) - which is not valid JSON, resulting in a JS error, and sudomode forever spinning it's loading indicator.

The chosen resolution is to open the sudomode controller to _all_ users, which also means it can be used outside of the admin context (e.g. "front-end" verification). This change is considered safe, and not a security concern at this time.