### PR TITLE
FIX point sudomode help link to userhelp not google

### DIFF
--- a/src/Control/SudoModeController.php
+++ b/src/Control/SudoModeController.php
@@ -39,7 +39,7 @@ class SudoModeController extends LeftAndMain
      * @config
      * @var string
      */
-    private static $help_link = 'http://google.com';
+    private static $help_link = 'https://userhelp.silverstripe.org/en/4/optional_features/multi-factor_authentication/user_manual/managing_your_mfa_settings/#managing-your-mfa-settings';
 
     /**
      * @var SudoModeServiceInterface

--- a/src/Control/SudoModeController.php
+++ b/src/Control/SudoModeController.php
@@ -39,6 +39,7 @@ class SudoModeController extends LeftAndMain
      * @config
      * @var string
      */
+    // phpcs:ignore 
     private static $help_link = 'https://userhelp.silverstripe.org/en/4/optional_features/multi-factor_authentication/user_manual/managing_your_mfa_settings/#managing-your-mfa-settings';
 
     /**


### PR DESCRIPTION
It's not very useful to have a hardcoded help link that points to Google!

I found a reference to 'http://google.com' in the test `client/src/containers/SudoMode/tests/SudoMode-test.js` as well but decided to leave that there given it seems to just check for the presence of a link.

Here's a gif of me testing this fix:
![sudomode-help-link](https://user-images.githubusercontent.com/15868440/76574810-3e7e9d00-6522-11ea-9131-5f968a2ee418.gif)
