### PR TITLE
FIX point sudomode help link to userhelp not google

### DIFF
--- a/src/Control/SudoModeController.php
+++ b/src/Control/SudoModeController.php
@@ -37,6 +37,7 @@ class SudoModeController extends LeftAndMain
      * @config
      * @var string
      */
+    // phpcs:ignore 
     private static $help_link = 'https://userhelp.silverstripe.org/en/4/optional_features/multi-factor_authentication/user_manual/managing_your_mfa_settings/#managing-your-mfa-settings';
 
     /**

--- a/src/Control/SudoModeController.php
+++ b/src/Control/SudoModeController.php
@@ -37,7 +37,7 @@ class SudoModeController extends LeftAndMain
      * @config
      * @var string
      */
-    private static $help_link = 'http://google.com';
+    private static $help_link = 'https://userhelp.silverstripe.org/en/4/optional_features/multi-factor_authentication/user_manual/managing_your_mfa_settings/#managing-your-mfa-settings';
 
     /**
      * @var SudoModeServiceInterface


### PR DESCRIPTION
It's not very useful to have a hardcoded help link that points to Google!

There's another PR for the 4.0 branch here: https://github.com/silverstripe/silverstripe-security-extensions/pull/29